### PR TITLE
Build problem when using cabal sandboxes

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,25 +1,29 @@
+import Control.Monad (void, when)
 import Distribution.Simple
-import Distribution.Simple.Setup (BuildFlags)
+import Distribution.Simple.Setup (BuildFlags, fromFlagOrDefault, buildDistPref)
 import Distribution.PackageDescription (HookedBuildInfo, emptyHookedBuildInfo)
 import System.Cmd (system)
 import System.Directory (doesFileExist, createDirectoryIfMissing)
-
-import Control.Monad (when)
+import System.FilePath ((</>))
 
 main :: IO ()
-main = defaultMainWithHooks $ simpleUserHooks { preBuild = preBuild' }
-  where
-    preBuild' :: Args -> BuildFlags -> IO HookedBuildInfo
-    preBuild' _ _ = do
-      maybeRunC2HS
-      return emptyHookedBuildInfo
+main = defaultMainWithHooks $ simpleUserHooks { preBuild = maybeRunC2HS }
 
 -- Because of a problem with Cabal dependency resolution of .chs
 -- files, we need to execute C2HS manually on these two files
-maybeRunC2HS = do 
-  existsA <- doesFileExist "dist/build/Foreign/OpenCL/Bindings/Internal/Types.chi"
-  when (not existsA) $ do
-    let c2hs_args="--output-dir=dist/build --include=dist/build  --cppopts=-Iinclude --cppopts=-U__BLOCKS__"
-    createDirectoryIfMissing True "dist/build/Foreign/OpenCL/Bindings/Internal"
-    _ <- system $ "c2hs " ++ c2hs_args ++ " Foreign/OpenCL/Bindings/Internal/Types.chs"
-    return ()
+maybeRunC2HS :: Args -> BuildFlags -> IO HookedBuildInfo
+maybeRunC2HS _args flags = do
+    chiExists <- doesFileExist chiFile
+    when (not chiExists) $ do
+      let c2hs_args = "--output-dir=" ++ buildDir ++
+                      " --include=" ++ buildDir ++
+                      " --cppopts=-Iinclude --cppopts=-U__BLOCKS__"
+      createDirectoryIfMissing True internalDir
+      void $ system $ "c2hs " ++ c2hs_args ++ chsFile
+    return emptyHookedBuildInfo
+  where
+    distDir = fromFlagOrDefault "dist" (buildDistPref flags)
+    buildDir = distDir </> "build"
+    internalDir = buildDir </> "Foreign/OpenCL/Bindings/Internal"
+    chiFile = internalDir </> "Types.chi"
+    chsFile = internalDir </> "Types.chs"


### PR DESCRIPTION
The build script assumes that `dist/` is the output path, but when built using cabal in a sandbox the output path is something like `dist/dist-sandbox-da44256f`. The fix is to get the actual output path from the parameters passed in from cabal.
